### PR TITLE
Trac 7606 api call should return 404 when there are no nf ts for given public key

### DIFF
--- a/apiHandler/nftHandler.go
+++ b/apiHandler/nftHandler.go
@@ -291,7 +291,12 @@ func GetNFTByBlockchainAndUserPK(w http.ResponseWriter, r *http.Request) {
 		results, err := marketplaceBusinessFacade.GetNFTByBlockchainAndUserPK(vars["currentownerpk"], vars["blockchain"])
 		if err != nil {
 			errors.BadRequest(w, err.Error())
+			return
 		} else {
+			if results == nil {
+				errors.BadRequest(w, "No Content")
+				return
+			}
 			commonResponse.SuccessStatus[[]models.NFT](w, results)
 		}
 	} else {


### PR DESCRIPTION
api call should return 404 when there are no nf ts for given public key